### PR TITLE
Add resource policy example with s3 bucket resource type flag. Two CD checks and invalid VPC/E

### DIFF
--- a/01-validate-policy/resource-s3-bucket-policy.json
+++ b/01-validate-policy/resource-s3-bucket-policy.json
@@ -1,0 +1,58 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ses.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::bucket-name/*",
+      "Condition": {
+        "StringLike": {
+          "aws:Referer": "111122223333"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::bucket-name/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::111122223333:saml-provider/idp_SSO_27fdff54821a3a61_DO_NOT_DELETE"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::bucket-name/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "111122223333"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::bucket-name",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceVpc": "vpc-1122334455667788900"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::bucket-name",
+      "Condition": {
+        "StringEquals": {
+          "aws:sourceVpc": "tr*"
+        }
+      }
+    }
+  ]
+}

--- a/01-validate-policy/validate-s3-bucket-resource-policy.sh
+++ b/01-validate-policy/validate-s3-bucket-resource-policy.sh
@@ -1,0 +1,1 @@
+aws accessanalyzer validate-policy --policy-type RESOURCE_POLICY --validate-policy-resource-type AWS::S3::Bucket --policy-document file://resource-s3-bucket-policy.json


### PR DESCRIPTION
…nfused Deputy examples included

	new file:   resource-s3-bucket-policy.json
	new file:   validate-s3-bucket-resource-policy.sh

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
